### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/pers/adar/hsn/buffer/pool/BufferPool.java
+++ b/src/main/java/pers/adar/hsn/buffer/pool/BufferPool.java
@@ -53,7 +53,7 @@ public class BufferPool implements Closeable {
 	private GenericObjectPool<ChannelBuffer> buildPool(int corePoolSize, int maxPoolSize, int keepAliveTime, int bufferSize) {
 		GenericObjectPoolConfig poolConfig = buildPoolConfig(corePoolSize, maxPoolSize, keepAliveTime);
 		
-		return new GenericObjectPool<ChannelBuffer>(new BufferFactory(bufferSize), poolConfig);
+		return new GenericObjectPool<>(new BufferFactory(bufferSize), poolConfig);
 	}
 	
 	private GenericObjectPoolConfig buildPoolConfig(int corePoolSize, int maxPoolSize, int keepAliveTime) {
@@ -82,7 +82,7 @@ public class BufferPool implements Closeable {
 	
 		@Override
 		public PooledObject<ChannelBuffer> makeObject() throws Exception {
-			return new DefaultPooledObject<ChannelBuffer>(new ChannelBuffer(ByteBuffer.allocateDirect(bufferSize)));
+			return new DefaultPooledObject<>(new ChannelBuffer(ByteBuffer.allocateDirect(bufferSize)));
 		}
 	
 		@Override

--- a/src/main/java/pers/adar/hsn/component/ChannelSelector.java
+++ b/src/main/java/pers/adar/hsn/component/ChannelSelector.java
@@ -36,7 +36,7 @@ public class ChannelSelector implements Runnable {
 
 	private Selector selector;
 	
-	private final Queue<RegisterChannel> registerChannels = new LinkedBlockingQueue<RegisterChannel>();
+	private final Queue<RegisterChannel> registerChannels = new LinkedBlockingQueue<>();
 	
 	public ChannelSelector(HsnServer server) throws IOException {
 		this.server = server;

--- a/src/main/java/pers/adar/hsn/component/ChannelSession.java
+++ b/src/main/java/pers/adar/hsn/component/ChannelSession.java
@@ -101,7 +101,7 @@ public class ChannelSession {
 	
 	public void setAttribute(String name, Object value) {
 		if (attributes == null) {
-			attributes = new HashMap<String, Object>();
+			attributes = new HashMap<>();
 		}
 		
 		attributes.put(name, value);

--- a/src/main/java/pers/adar/hsn/core/HsnServer.java
+++ b/src/main/java/pers/adar/hsn/core/HsnServer.java
@@ -42,7 +42,7 @@ public class HsnServer {
 
 	private int bufferPoolSize = HsnProperties.DEFAULT_BUFFER_POOL_SIZE;
 	
-	private Map<SocketOption, Object> socketOptions = new HashMap<SocketOption, Object>();
+	private Map<SocketOption, Object> socketOptions = new HashMap<>();
 	
 	private AcceptProcessor acceptProcessor;
 	

--- a/src/main/java/pers/adar/hsn/core/TaskProcessor.java
+++ b/src/main/java/pers/adar/hsn/core/TaskProcessor.java
@@ -106,7 +106,7 @@ public class TaskProcessor implements Closeable {
 		@SuppressWarnings("unchecked")
 		BlockingQueue<ChannelTask>[] channelTaskQueues = new LinkedBlockingQueue[server.channelThreadCount()];
 		for (int i = 0; i < channelTaskQueues.length; i++) {
-			channelTaskQueues[i] = new LinkedBlockingQueue<ChannelTask>();
+			channelTaskQueues[i] = new LinkedBlockingQueue<>();
 		}
 		
 		return channelTaskQueues;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava