### PR TITLE
Multiple code improvements - squid:S1118, squid:S1854, squid:S1213

### DIFF
--- a/src/main/java/pers/adar/hsn/common/HsnProperties.java
+++ b/src/main/java/pers/adar/hsn/common/HsnProperties.java
@@ -17,8 +17,10 @@
  */
 package pers.adar.hsn.common;
 
-public class HsnProperties {
-	
+public final class HsnProperties {
+
+	private HsnProperties() {}
+
 	public static final String HSN = "HSN";
 	
 	public static final int DEFAULT_CHANNEL_SELECTOR_COUNT = Runtime.getRuntime().availableProcessors();

--- a/src/main/java/pers/adar/hsn/common/HsnThreadFactory.java
+++ b/src/main/java/pers/adar/hsn/common/HsnThreadFactory.java
@@ -20,8 +20,10 @@ package pers.adar.hsn.common;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class HsnThreadFactory {
-	
+public final class HsnThreadFactory {
+
+	private HsnThreadFactory() {}
+
 	public static ThreadFactory buildAcceptSelectorFactory() {
 		return new AcceptSelectorFactory();
 	}

--- a/src/main/java/pers/adar/hsn/component/ChannelHandler.java
+++ b/src/main/java/pers/adar/hsn/component/ChannelHandler.java
@@ -26,8 +26,10 @@ import pers.adar.hsn.logger.Logger;
 import pers.adar.hsn.task.impl.ChannelReadTask;
 import pers.adar.hsn.task.impl.ChannelWriteTask;
 
-public class ChannelHandler {
-	
+public final class ChannelHandler {
+
+	private ChannelHandler() {}
+
 	public static void handlerAccpet(HsnServer server, SelectionKey selectionKey) throws Exception {
 		ServerSocketChannel serverSocketChannel = (ServerSocketChannel) selectionKey.channel();
 		SocketChannel socketChannel = serverSocketChannel.accept();

--- a/src/main/java/pers/adar/hsn/component/ChannelSelector.java
+++ b/src/main/java/pers/adar/hsn/component/ChannelSelector.java
@@ -90,7 +90,7 @@ public class ChannelSelector implements Runnable {
 	}
 	
 	private void processRegisterChannels() {
-		RegisterChannel registerChannel = null;
+		RegisterChannel registerChannel;
 		while ((registerChannel = registerChannels.poll()) != null) {
 			try {
 				registerChannel.channel.register(selector, registerChannel.interestOps, registerChannel.channelSession);

--- a/src/main/java/pers/adar/hsn/logger/Logger.java
+++ b/src/main/java/pers/adar/hsn/logger/Logger.java
@@ -19,7 +19,9 @@ package pers.adar.hsn.logger;
 
 import pers.adar.hsn.common.HsnProperties;
 
-public class Logger {
+public final class Logger {
+
+	private Logger() {}
 
 	private static final org.slf4j.Logger HSN_LOGGER = org.slf4j.LoggerFactory.getLogger(HsnProperties.HSN);
 	

--- a/src/main/java/pers/adar/hsn/task/impl/AbstractChannelTask.java
+++ b/src/main/java/pers/adar/hsn/task/impl/AbstractChannelTask.java
@@ -24,6 +24,11 @@ public abstract class AbstractChannelTask implements ChannelTask {
 
 	protected ChannelSession channelSession;
 
+	protected AbstractChannelTask(ChannelSession channelSession) {
+		super();
+		this.channelSession = channelSession;
+	}
+
 	@Override
 	public ChannelSession channelSession() {
 		return channelSession;
@@ -34,8 +39,4 @@ public abstract class AbstractChannelTask implements ChannelTask {
 		return channelSession.taskQueueIndex();
 	}
 
-	protected AbstractChannelTask(ChannelSession channelSession) {
-		super();
-		this.channelSession = channelSession;
-	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1854 - Dead stores should be removed.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava