### PR TITLE
Multiple code improvements - squid:S1640, squid:S1148, squid:S00115

### DIFF
--- a/src/main/java/pers/adar/hsn/adaptor/impl/FileChannelAdaptor.java
+++ b/src/main/java/pers/adar/hsn/adaptor/impl/FileChannelAdaptor.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import pers.adar.hsn.component.ChannelSession.ChannelContext;
+import pers.adar.hsn.logger.Logger;
 
 public class FileChannelAdaptor extends StandardChannelAdaptor {
 
@@ -35,7 +36,7 @@ public class FileChannelAdaptor extends StandardChannelAdaptor {
 		try (FileChannel fileChannel = FileChannel.open(Paths.get(DIR + now()), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
 			fileChannel.write(channelContext.read());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Logger.error(e.getMessage(), e);
 		}
 		
 		channelContext.close();

--- a/src/main/java/pers/adar/hsn/common/HsnThreadFactory.java
+++ b/src/main/java/pers/adar/hsn/common/HsnThreadFactory.java
@@ -36,13 +36,13 @@ public class HsnThreadFactory {
 	
 	private static class AcceptSelectorFactory implements ThreadFactory {
 		
-		private static final String mark = "AcceptSelector";
+		private static final String MARK = "AcceptSelector";
 
 		@Override
 		public Thread newThread(Runnable runnable) {
 			Thread thread = new Thread(runnable);
 			thread.setPriority(Thread.MAX_PRIORITY);
-			thread.setName(mark);
+			thread.setName(MARK);
 			
 			return thread;
 		}
@@ -50,7 +50,7 @@ public class HsnThreadFactory {
 
 	private static class ChannelSelectorFactory implements ThreadFactory {
 		
-		private static final String mark = "ChannelSelector-";
+		private static final String MARK = "ChannelSelector-";
 		
 		private final AtomicInteger id = new AtomicInteger(0);
 
@@ -59,7 +59,7 @@ public class HsnThreadFactory {
 			Thread thread = new Thread(runnable);
 			thread.setDaemon(true);
 			thread.setPriority(Thread.MAX_PRIORITY);
-			thread.setName(mark + id.incrementAndGet());
+			thread.setName(MARK + id.incrementAndGet());
 			
 			return thread;
 		}
@@ -67,7 +67,7 @@ public class HsnThreadFactory {
 	
 	private static class ChannelHandlerFactory implements ThreadFactory {
 		
-		private static final String mark = "ChannelHandler-";
+		private static final String MARK = "ChannelHandler-";
 		
 		private final AtomicInteger id = new AtomicInteger(0);
 
@@ -76,7 +76,7 @@ public class HsnThreadFactory {
 			Thread thread = new Thread(runnable);
 			thread.setDaemon(true);
 			thread.setPriority(Thread.MAX_PRIORITY);
-			thread.setName(mark + id.incrementAndGet());
+			thread.setName(MARK + id.incrementAndGet());
 			
 			return thread;
 		}

--- a/src/main/java/pers/adar/hsn/core/HsnServer.java
+++ b/src/main/java/pers/adar/hsn/core/HsnServer.java
@@ -18,6 +18,7 @@
 package pers.adar.hsn.core;
 
 import java.io.IOException;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,7 +43,7 @@ public class HsnServer {
 
 	private int bufferPoolSize = HsnProperties.DEFAULT_BUFFER_POOL_SIZE;
 	
-	private Map<SocketOption, Object> socketOptions = new HashMap<>();
+	private EnumMap<SocketOption, Object> socketOptions = new EnumMap<>(SocketOption.class);
 	
 	private AcceptProcessor acceptProcessor;
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1640 - Maps with keys that are enum values should be replaced with EnumMap.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1640
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
George Kankava