### PR TITLE
Multiple code improvements - squid:MethodCyclomaticComplexity, squid:S134, squid:S2325

### DIFF
--- a/src/main/java/pers/adar/hsn/adaptor/impl/FileChannelAdaptor.java
+++ b/src/main/java/pers/adar/hsn/adaptor/impl/FileChannelAdaptor.java
@@ -41,7 +41,7 @@ public class FileChannelAdaptor extends StandardChannelAdaptor {
 		channelContext.close();
 	}
 	
-	private String now() {
+	private static String now() {
 		return new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
 	}
 }

--- a/src/main/java/pers/adar/hsn/buffer/pool/BufferPool.java
+++ b/src/main/java/pers/adar/hsn/buffer/pool/BufferPool.java
@@ -56,7 +56,7 @@ public class BufferPool implements Closeable {
 		return new GenericObjectPool<>(new BufferFactory(bufferSize), poolConfig);
 	}
 	
-	private GenericObjectPoolConfig buildPoolConfig(int corePoolSize, int maxPoolSize, int keepAliveTime) {
+	private static GenericObjectPoolConfig buildPoolConfig(int corePoolSize, int maxPoolSize, int keepAliveTime) {
 		GenericObjectPoolConfig config = new GenericObjectPoolConfig();
 		config.setMaxIdle(corePoolSize);
 		config.setMaxTotal(maxPoolSize);

--- a/src/main/java/pers/adar/hsn/component/ChannelSelector.java
+++ b/src/main/java/pers/adar/hsn/component/ChannelSelector.java
@@ -62,17 +62,7 @@ public class ChannelSelector implements Runnable {
 			Set<SelectionKey> keys = selector.selectedKeys();
 			for (SelectionKey key : keys) {
 				try{
-					if (!key.isValid()) {
-						continue;
-					}
-					
-					if (key.isAcceptable()) {
-						ChannelHandler.handlerAccpet(server, key);
-					} else if (key.isReadable()) {
-						ChannelHandler.handlerRead(server, key);
-					} else if (key.isWritable()) {
-						ChannelHandler.handlerWrite(server, key);
-					}
+					handle(key);
 				} catch (InterruptedException e) {
 					Thread.currentThread().interrupt();
 				} catch(Throwable throwable){
@@ -88,7 +78,17 @@ public class ChannelSelector implements Runnable {
 			keys.clear();
 		}
 	}
-	
+
+	private void handle(SelectionKey key) throws Exception {
+		if (key.isValid() && key.isAcceptable()) {
+			ChannelHandler.handlerAccpet(server, key);
+		} else if (key.isReadable()) {
+			ChannelHandler.handlerRead(server, key);
+		} else if (key.isWritable()) {
+			ChannelHandler.handlerWrite(server, key);
+		}
+	}
+
 	private void processRegisterChannels() {
 		RegisterChannel registerChannel = null;
 		while ((registerChannel = registerChannels.poll()) != null) {

--- a/src/main/java/pers/adar/hsn/core/AcceptProcessor.java
+++ b/src/main/java/pers/adar/hsn/core/AcceptProcessor.java
@@ -97,7 +97,7 @@ public class AcceptProcessor implements Closeable {
 		return (SocketImpl) method.invoke(serverSocketChannel.socket(), new Object[0]);
 	}
 	
-	private ExecutorService buildAcceptExecutor() {
+	private static ExecutorService buildAcceptExecutor() {
 		return Executors.newSingleThreadExecutor(HsnThreadFactory.buildAcceptSelectorFactory());
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:MethodCyclomaticComplexity - Methods should not be too complex.
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
squid:S2325 - "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:S2325
Please let me know if you have any questions.
George Kankava